### PR TITLE
Fix missing data objects in scrData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SCRbayes
 Type: Package
 Title: Bayesian analysis of spatial capture-recapture models
-Version: 0.20
+Version: 0.20.1
 Date: 2013-12-07
 Author: several
 Maintainer: Andy Royle <aroyle@usgs.gov>

--- a/R/scrData.R
+++ b/R/scrData.R
@@ -25,9 +25,10 @@ function(traps,captures,statespace,alive=NULL,
  session=rep(1,nrow(captures))
 }else{
  session<- captures[,"session"]
+}
 individual<-captures[,"individual"]
 occasion<-captures[,"occasion"]
-trapid<- captures[,"trapid"]}
+trapid<- captures[,"trapid"]
 captures<-cbind(session=session,individual=individual,occasion=occasion,trapid=trapid)
 
 


### PR DESCRIPTION
User Stéphanie Périquet reported a bug via the mailing list

```
library(SCRbayes)
data(lions)

dimnames(captures.lions)<-
   list(1:nrow(captures.lions),c("trapid","individual","occasion"))

lion.scrdata <- scrData(traps.lions,captures.lions,statespace.lions)
```

This PR addresses this issue by making sure not only session is created in case  `captures` argument only has three columns.

Mass change in `DESCRIPTION` is due to my (Fedora) system changing line ends with something different than what you have (assuming Windows' LF, see [core.autocrlf](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)). And I just wanted to pump bugfix number... :)